### PR TITLE
Update README to remove initializing submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compilation
 Gradle is used to handle dependencies.
 
 - Clone the repo: `git clone https://github.com/LapisBlue/Pore.git`
-- Compile the project using the Gradle wrapper: `./gradlew`
+- Compile the project using the Gradle wrapper: `./gradlew` (`gradlew` on Windows)
 
 Licensing
 ---------


### PR DESCRIPTION
When cloning a repository, it's possible to automatically initialize submodules by using `git clone --recursive`.

This PR updates the README to use this,  removing one step.
